### PR TITLE
[A47] fix: followingCount of UserOther (#88)

### DIFF
--- a/src/views/UserOther.vue
+++ b/src/views/UserOther.vue
@@ -66,6 +66,7 @@ export default {
     this.userId = Number(userId)
     this.fetchUser(this.userId)
     this.updateRouteName(to.name)
+    this.updatePage()
     next()
   },
   data () {


### PR DESCRIPTION
[A47] fix: followingCount of UserOther doesn’t update while switch users in RecommendColumn
@tommy0311 @eddie8119 @JasonChan1129 
ready for review